### PR TITLE
Use GPU and batch the training sample if requested

### DIFF
--- a/python/utils.py
+++ b/python/utils.py
@@ -31,8 +31,9 @@ def sample_flow(flow: flows.Flow, n_samples: int) -> torch.Tensor:
     return samples
 
 
-def train_flow(flow: flows.Flow, target_data: torch.Tensor, n_iter: int, plot_path: str, xrange=(-4, 0), use_gpu=False) -> None:
+def train_flow(flow: flows.Flow, target_data: torch.Tensor, n_iter: int, plot_path: str, xrange=(-4, 0), use_gpu=False, batch_the_data=False) -> None:
     # Train the flow, and periodically plot the results
+    # Batching the data for 100k events with 1 input feature is slower than not batching, but it was interesting to add the functionality.
     binning = dict(bins=100, range=xrange)
 
     # Setup the plot
@@ -44,15 +45,29 @@ def train_flow(flow: flows.Flow, target_data: torch.Tensor, n_iter: int, plot_pa
     # Put everything on the GPU if it is available and desired
     device = "cuda" if (torch.cuda.is_available() and use_gpu) else "cpu"
     print(f"INFO:\tUsing device: {device}")
-    target_data = target_data.to(device)
     flow = flow.to(device)
+    target_data = target_data.to(device)
+    if batch_the_data:
+        batch_size = 64
+        target_data_dl = torch.utils.data.DataLoader(target_data, batch_size=batch_size, shuffle=False)
 
     optimizer = torch.optim.Adam(flow.parameters())
     for i in range(n_iter+1):
-        optimizer.zero_grad()
-        loss = -flow.log_prob(inputs=target_data).mean()
-        loss.backward()
-        optimizer.step()
+
+        if batch_the_data:
+            loss = 0
+            for batch in target_data_dl:
+                # batch = batch.to(device)
+                optimizer.zero_grad()
+                batch_loss = -flow.log_prob(inputs=batch).mean()
+                loss += batch_loss
+                batch_loss.backward()
+                optimizer.step()
+        else:
+            optimizer.zero_grad()
+            loss = -flow.log_prob(inputs=target_data).mean()
+            loss.backward()
+            optimizer.step()
 
         if i % (n_iter/5) != 0:
             continue

--- a/python/utils.py
+++ b/python/utils.py
@@ -57,7 +57,6 @@ def train_flow(flow: flows.Flow, target_data: torch.Tensor, n_iter: int, plot_pa
         if batch_the_data:
             loss = 0
             for batch in target_data_dl:
-                # batch = batch.to(device)
                 optimizer.zero_grad()
                 batch_loss = -flow.log_prob(inputs=batch).mean()
                 loss += batch_loss

--- a/python/utils.py
+++ b/python/utils.py
@@ -31,7 +31,7 @@ def sample_flow(flow: flows.Flow, n_samples: int) -> torch.Tensor:
     return samples
 
 
-def train_flow(flow: flows.Flow, target_data: torch.Tensor, n_iter: int, plot_path: str, xrange=(-4, 0)) -> None:
+def train_flow(flow: flows.Flow, target_data: torch.Tensor, n_iter: int, plot_path: str, xrange=(-4, 0), use_gpu=False) -> None:
     # Train the flow, and periodically plot the results
     binning = dict(bins=100, range=xrange)
 
@@ -40,6 +40,12 @@ def train_flow(flow: flows.Flow, target_data: torch.Tensor, n_iter: int, plot_pa
     ax = ax.flatten()
     hist_target, bins = np.histogram(target_data, **binning)
     i_fig = 0
+
+    # Put everything on the GPU if it is available and desired
+    device = "cuda" if (torch.cuda.is_available() and use_gpu) else "cpu"
+    print(f"INFO:\tUsing device: {device}")
+    target_data = target_data.to(device)
+    flow = flow.to(device)
 
     optimizer = torch.optim.Adam(flow.parameters())
     for i in range(n_iter+1):
@@ -60,13 +66,17 @@ def train_flow(flow: flows.Flow, target_data: torch.Tensor, n_iter: int, plot_pa
 
             # Sample from the flow and plot the histogram
             samples = sample_flow(flow, target_data.shape[0])
-            pred_hist, bins = np.histogram(samples, **binning)
+            pred_hist, bins = np.histogram(samples.cpu(), **binning) # move to cpu for plotting
             ax[i_fig].bar(x=bins[:-1], height=pred_hist, yerr=np.sqrt(pred_hist), width=bins[1] - bins[0], label='Flow', fill=False, edgecolor='red')
 
             ax[i_fig].legend()
             i_fig += 1
 
     plt.savefig(plot_path)
+
+    # Put everything back on the CPU for plotting etc. downstream
+    target_data.cpu()
+    flow.cpu()
 
 
 def load_data(sample_type: str, n_samples: int) -> torch.Tensor:

--- a/scripts/flow_to_lhcb_ip_sim.py
+++ b/scripts/flow_to_lhcb_ip_sim.py
@@ -28,12 +28,10 @@ def main():
             utils.sample_flow(quad_flow, n_samples), plot_path("flow_sample_pretrain"))
 
     print("INFO:\tTraining flow...")
-    utils.train_flow(quad_flow, target_data, n_iter=10000, plot_path=plot_path("training"))
+    utils.train_flow(quad_flow, target_data, n_iter=10000, plot_path=plot_path("training"), use_gpu=True)
     with torch.inference_mode():
         utils.plot_from_sample(
             utils.sample_flow(quad_flow, n_samples), plot_path("flow_sample_posttrain"))
-
-    with torch.inference_mode():
         utils.benchmark_hep_style(quad_flow, target_data, plot_path=plot_path("performance_plots"))
 
     print("INFO:\tFlow training complete. Please find plots under plots/")

--- a/scripts/ip_correction_flow.py
+++ b/scripts/ip_correction_flow.py
@@ -51,6 +51,7 @@ def plot_single_transform(target_sample: torch.Tensor, init_sample: torch.Tensor
 def main():
     parser = argparse.ArgumentParser(description="Train a flow to correct the LHCb IP simulation to match the data.")
     parser.add_argument("--test", action="store_true", help="Run with smaller datasets and less training iterations for testing purposes.")
+    parser.add_argument("--train-on-gpu", action="store_true")
     args = parser.parse_args()
 
     if args.test:
@@ -85,12 +86,10 @@ def main():
 
         print("INFO:\tTraining flow...")
         # Generally requires 10k iterations
-        utils.train_flow(quad_flow, target_data, n_iter=n_iter, plot_path=plot_path(target_sample, "training"))
+        utils.train_flow(quad_flow, target_data, n_iter=n_iter, plot_path=plot_path(target_sample, "training"), use_gpu=args.train_on_gpu)
         with torch.inference_mode():
             utils.plot_from_sample(
                 utils.sample_flow(quad_flow, n_candidates), plot_path(target_sample, "posttrain"))
-
-        with torch.inference_mode():
             utils.benchmark_hep_style(quad_flow, target_data, plot_path=plot_path(target_sample, "performance_plots"))
 
         trained_transforms[target_sample] = transform


### PR DESCRIPTION
Changes the shared `train_flow` function to put the sample tensors and the flow on the GPU if requested.

Provides `--train-on-gpu` flag for `ip_correction_flow.py` to enable this on demand, while `flow_to_lhcb_ip_sim.py` now does this by default. 

Also enables batching of the training data sample, but this is switched off by default as it shows no performance gain. 

Using the GPU currently shows no performance gain (runtime of `flow_to_lhcb_ip_sim.py` is unchanged by toggling the GPU usage off or on on my machine), which probably shows that the sample size and computational complexity isn't sufficient for a speed up. Further studies would be required to speed up the training e.g. into the hyperparameters, required training sample size and number of iterations, learning rate etc. 

Closes #5. 